### PR TITLE
Change error message for invalid url

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -12,7 +12,7 @@ function validate(url) {
 
 async function read(url) {
   if (!validate(url)) {
-    throw new Error("invalid URL");
+    throw new Error("invalid url");
   }
 
   const response = await got(url);

--- a/lib/url.js
+++ b/lib/url.js
@@ -16,7 +16,7 @@ async function read(url) {
   }
 
   const response = await got(url);
-  return response.body;
+  return '';
 }
 
 module.exports.validate = validate;

--- a/lib/url.js
+++ b/lib/url.js
@@ -16,7 +16,7 @@ async function read(url) {
   }
 
   const response = await got(url);
-  return '';
+  return response.body;
 }
 
 module.exports.validate = validate;


### PR DESCRIPTION
This change alters the way that we display an error message when a URL is invalid, using lower-case.